### PR TITLE
Amazon a9 bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,12 @@ arcAds.registerAd({
 ```
 
 ### Amazon TAM/A9
-You can enable Amazon A9/TAM on the service by adding an `amazon` object to the wrapper initialization and then passing it `enabled: true`. You must also provide your publication id that corresponds to the owners Amazon account. Unlike Prebid.js, the Amazon initialization script is included inside of the wrapper.
+You can enable Amazon A9/TAM on the service by adding an `amazon` object to the wrapper initialization and then passing it `enabled: true`. You must also include the `apstag` script on your page with: 
+```
+<script src="https://c.amazon-adsystem.com/aax2/apstag.js"></script>
+```
+
+You must also provide your publication id that corresponds to the owners Amazon account.
 
 ```javascript
 const arcAds = new ArcAds({

--- a/src/services/amazon.js
+++ b/src/services/amazon.js
@@ -32,9 +32,5 @@ export function fetchAmazonBids(id, slotName, dimensions, cb = null) {
 export function queueAmazonCommand(cmd) {
   if (window.apstag) {
     cmd();
-  } else {
-    setTimeout(() => {
-      queueAmazonCommand(cmd);
-    }, 200);
   }
 }

--- a/src/services/headerbidding.js
+++ b/src/services/headerbidding.js
@@ -28,24 +28,22 @@ export function initializeBiddingServices({
   });
 
   const enableAmazon = new Promise((resolve) => {
-    if (amazon && amazon.enabled) {
-      appendResource('script', '//c.amazon-adsystem.com/aax2/apstag.js', true, true, () => {
-        if (amazon.id && amazon.id !== '') {
-          queueAmazonCommand(() => {
-            // Initializes the Amazon APS tag script.
-            window.apstag.init({
-              pubID: amazon.id,
-              adServer: 'googletag'
-            });
-
-            resolve('Amazon scripts have been added onto the page!');
+    if (amazon && amazon.enabled && window.apstag) {
+      if (amazon.id && amazon.id !== '') {
+        queueAmazonCommand(() => {
+          // Initializes the Amazon APS tag script.
+          window.apstag.init({
+            pubID: amazon.id,
+            adServer: 'googletag'
           });
-        } else {
-          console.warn(`ArcAds: Missing Amazon account id. 
-            Documentation: https://github.com/wapopartners/arc-ads#amazon-tama9`);
-          resolve('Amazon is not enabled on the wrapper...');
-        }
-      });
+
+          resolve('Amazon scripts have been added onto the page!');
+        });
+      } else {
+        console.warn(`ArcAds: Missing Amazon account id. 
+          Documentation: https://github.com/wapopartners/arc-ads#amazon-tama9`);
+        resolve('Amazon is not enabled on the wrapper...');
+      }
     } else {
       resolve('Amazon is not enabled on the wrapper...');
     }


### PR DESCRIPTION
## On this branch
Fixes bug of amazon a9 not loading script when using ad blocker

## To Verify
1. Add the `apstag` script to the `<head>` element and described in the readme
2. `window.apstag` gets initialized and A9 is working