### PR TITLE
Allow use of breakpoints instead of user-agent sniffing

### DIFF
--- a/src/__tests__/util.test.js
+++ b/src/__tests__/util.test.js
@@ -1,3 +1,4 @@
+import { BreakpointDetection } from '../util/breakpoint';
 import { renamePositionKey } from '../util/customTargeting';
 
 describe('The CustomTargeting.js functions', () => {
@@ -15,5 +16,26 @@ describe('The CustomTargeting.js functions', () => {
     };
 
     expect(updatedTargeting).toEqual(newTargeting);
+  });
+});
+
+describe('BreakpointDetection', () => {
+  it('should initialize', () => {
+    const breakpointDetection = new BreakpointDetection(720);
+    expect(breakpointDetection).not.toBeUndefined();
+  });
+
+  it('should detect small devices as mobile', () => {
+    window.innerWidth = 320;
+    const breakpointDetection = new BreakpointDetection(720);
+    const isMobile = breakpointDetection.any();
+    expect(isMobile).toBeTrue();
+  });
+
+  it('should detect large devices as desktop', () => {
+    window.innerWidth = 1044;
+    const breakpointDetection = new BreakpointDetection(720);
+    const isMobile = breakpointDetection.any();
+    expect(isMobile).toBeFalse();
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { MobileDetection } from './util/mobile';
+import { BreakpointDetection } from './util/breakpoint';
 import { fetchBids, initializeBiddingServices } from './services/headerbidding';
 import { initializeGPT, queueGoogletagCommand, refreshSlot, dfpSettings, setTargeting, determineSlotName } from './services/gpt';
 import { queuePrebidCommand, addUnit } from './services/prebid';
@@ -12,7 +13,11 @@ export class ArcAds {
     this.positions = [];
     this.collapseEmptyDivs = options.dfp.collapseEmptyDivs;
 
-    window.isMobile = MobileDetection;
+    if (options.desktopBreakpoint) {
+      window.isMobile = new BreakpointDetection(options.desktopBreakpoint);
+    } else {
+      window.isMobile = MobileDetection;
+    }
 
     if (this.dfpId === '') {
       console.warn(`ArcAds: DFP id is missing from the arcads initialization script. 

--- a/src/util/breakpoint.js
+++ b/src/util/breakpoint.js
@@ -1,4 +1,6 @@
 /** @desc Utility class that determines the breakpoint based on window width. **/
+import MobileDetection from './mobile';
+
 export class BreakpointDetection {
   /**
    * @desc Constructor.
@@ -6,6 +8,13 @@ export class BreakpointDetection {
    **/
   constructor(desktopBreakpoint) {
     this.desktopBreakpoint = desktopBreakpoint;
+  }
+
+  /**
+   * @desc Determines if the user is using a Retina display.
+   **/
+  Retina() {
+    return MobileDetection.Retina();
   }
 
   /**

--- a/src/util/breakpoint.js
+++ b/src/util/breakpoint.js
@@ -1,0 +1,17 @@
+/** @desc Utility class that determines the breakpoint based on window width. **/
+export class BreakpointDetection {
+  /**
+   * @desc Constructor.
+   * @param {number} desktopBreakpoint The minimum width at which the browser is considered desktop.
+   **/
+  constructor(desktopBreakpoint) {
+    this.desktopBreakpoint = desktopBreakpoint;
+  }
+
+  /**
+   * @desc Determines if the user is using a mobile device.
+   **/
+  any() {
+    return (window.innerWidth < this.desktopBreakpoint);
+  }
+}


### PR DESCRIPTION
Some publishers use only breakpoints to determine whether a device is mobile or desktop. This option allows those companies to more closely align device detection with their own policies.

This came up during testing of an unrelated issue. The Chrome developer tools device toolbar will modify the user-agent to appear like an Android device, even at widescreen values, preventing our right-rail ad from loading.

## On this branch
Adds option to ArcAds initialization to specify a desktop breakpoint using the `desktopBreakpoint` property. If present, that overrides the user-agent-based device detection.

#### Verify

- [X] Confirm that cross browser testing has been completed.

- [X] Verify that no errors are present in the GPT console `window.googletag.openConsole()`.
 

#### Comments
Sample initialization code:
```js
const arcAds = new ArcAds({
  dfp: {
    id: dfpPublisherID,
    collapseEmptyDivs: true,
  },
  desktopBreakpoint: 960,
});
```
