### PR TITLE
Add non-personalized ads option. Fix #50

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing to ArcAds
 
 Welcome to the contribution guide for ArcAds. Here are some important resources to get you started:
-  
+
   * [ArcAds Wiki](https://github.com/washingtonpost/ArcAds/wiki)
   * [Doubleclick for Publishers](http://www.google.com/dfp)
   * [Prebid.js](http://prebid.org/)
   * [Amazon A9](https://www.a9.com/)
-  
+
 ## Questions or Issues
 If you have a general question or an issue please refer to our [Frequently Asked Questions](https://github.com/washingtonpost/ArcAds/wiki/Frequently-Asked-Questions) section which we'll update reguarly with questions. If you can't find an answer to your question please open an [issue](https://github.com/washingtonpost/ArcAds/issues).
 
@@ -14,19 +14,19 @@ If you have a general question or an issue please refer to our [Frequently Asked
 ArcAds has a series of unit tests built with [Jest](https://facebook.github.io/jest/). We are always looking to improve our testing coverage , and request that if you create new functionality that you also include tests along with it.
 
 ## Submitting changes
-Please send a [Pull Request to ArcAds](https://github.com/washingtonpost/ArcAds/pull/new/master) with a clear list of what you've done (you read more about [Github pull requests here](http://help.github.com/pull-requests/)). 
+Please send a [Pull Request to ArcAds](https://github.com/washingtonpost/ArcAds/pull/new/master) with a clear list of what you've done (you read more about [Github pull requests here](http://help.github.com/pull-requests/)).
 Please follow the best practices guide below and make sure all of your commits are atomic (one feature per commit).
 
 Always write a clear log message for your commits. One-line messages are fine for small changes, but bigger changes should look like this:
 
     $ git commit -m "A brief summary of the commit
-    > 
+    >
     > A paragraph describing what changed and its impact."
 
 ## Best Practices
 
   * ArcAds gets linted with the [airbnb style guide](https://github.com/airbnb/javascript).
   * Code should be documented and commented using the [ESDoc](https://esdoc.org/) conventions.
-  * Please make sure you've tested your code prior to submitting a pull request and ensure everything works. 
+  * Please make sure you've tested your code prior to submitting a pull request and ensure everything works.
 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started you must include the script tag for ArcAds in your page header, l
 Additionally you can install the package with npm. This is mostly useful for when you're integrating ArcAds into a single page application or a JavaScript heavy project. Most implementations should just include the script in the page header.
 
 ```
-npm install arcads 
+npm install arcads
 ```
 
 You can then include it in your own JavaScript projects like so.
@@ -54,15 +54,15 @@ The following table shows all of the possible parameters the `registerAd` method
 
 | Parameter | Description | Type | Requirement |
 | ------------- | ------------- | ------------- | ------------- |
-| `id`  | The `id` parameter corresponds to a div id on the page that the advertisement should render into. | `String` | `Required` | 
+| `id`  | The `id` parameter corresponds to a div id on the page that the advertisement should render into. | `String` | `Required` |
 | `slotName`  | The `slotName` parameter is equal to the slot name configured within DFP, for example `sitename/hp/hp-1`. The publisher ID gets attached to the slot name within the ArcAds logic. | `String` | `Required` |
 | `dimensions`  | The `dimensions` parameter should be an array with array of arrays containing the advertisement sizes the slot can load. If left empty the advertisement will be considered as an out of page unit. | `Array` | `Optional` |
 | `adType`  | The `adType` parameter should describe the type of advertisement, for instance `leaderboard` or `cube`.  | `String` | `Optional` |
 | `display`  | The `display` paramter determines which user agents can render the advertisement. The available choices are `desktop`, `mobile`, or `all`. If a value is not provided it will default to `all`. | `String` | `Optional` |
 | `targeting`  | The `targeting` paramter accepts an object containing key/value pairs which should attached to the advertisement request. | `Object` | `Optional` |
 | `sizemap`  | The `sizemap` paramter accepts an object containing information about the advertisements size mapping, for more information refer to the [Size Mapping portion of the readme](https://github.com/washingtonpost/arcads#size-mapping). | `Object` | `Optional` |
-| `bidding`  | The `bidding` paramter accepts an object containing information about the advertisements header bidding vendors, for more information refer to the [Header Bidding portion of the readme](https://github.com/washingtonpost/arcads#header-bidding). | `Object` | `Optional` | 
-| `prerender`  | The `prerender` parameter accepts an a function that should fire before the advertisement loads, for more information refer to the [Prerender Hook portion of the readme](https://github.com/washingtonpost/arcads/tree/master#prerender-hook). | `Function` | `Optional` | 
+| `bidding`  | The `bidding` paramter accepts an object containing information about the advertisements header bidding vendors, for more information refer to the [Header Bidding portion of the readme](https://github.com/washingtonpost/arcads#header-bidding). | `Object` | `Optional` |
+| `prerender`  | The `prerender` parameter accepts an a function that should fire before the advertisement loads, for more information refer to the [Prerender Hook portion of the readme](https://github.com/washingtonpost/arcads/tree/master#prerender-hook). | `Function` | `Optional` |
 
 ### Out of Page Ads
 If an advertisement has an empty or missing `dimensions` parameter it will be considered as a [DFP Out of Page creative](https://support.google.com/dfp_premium/answer/6088046?hl=en) and rendered as such.
@@ -115,7 +115,7 @@ arcAds.registerAd({
 })
 ```
 
-The service will automatically give the advertisement a `position` target key/value pair if either the `targeting` object or `position` key of the targeting object are not present. The position value will incriment by 1 in sequence for each of the same `adType` on the page. This is a common practice between ad traffickers so this behavior is baked in, only if the trafficker makes use of this targeting will it have any effect on the advertisement rendering. 
+The service will automatically give the advertisement a `position` target key/value pair if either the `targeting` object or `position` key of the targeting object are not present. The position value will incriment by 1 in sequence for each of the same `adType` on the page. This is a common practice between ad traffickers so this behavior is baked in, only if the trafficker makes use of this targeting will it have any effect on the advertisement rendering.
 
 If `adType` is exluded from the `registerAd` call the automatic position targeting will not be included.
 
@@ -207,7 +207,7 @@ If you'd like to include Prebid.js you must include the library before `arcads.j
   const arcAds = new ArcAds({
     dfp: {
       id: '123'
-    }, 
+    },
     bidding: {
       prebid: {
         enabled: true
@@ -229,6 +229,16 @@ const arcAds = new ArcAds({
       enabled: true,
       timeout: 1000
     }
+  }
+}
+```
+For GDPR compliance, the `nonPersonalized` DFP option can be set:
+
+```javascript
+const arcAds = new ArcAds({
+  dfp: {
+    id: '123',
+    nonPersonalized: 1
   }
 }
 ```
@@ -270,14 +280,14 @@ const arcAds = new ArcAds({
             [728, 90]
           ],
           'labels': ['desktop']
-        }, 
+        },
         {
           'mediaQuery': '(min-width: 480px) and (max-width: 1023px)',
           'sizesSupported': [
             [728, 90]
           ],
           'labels': ['tablet']
-        }, 
+        },
         {
           'mediaQuery': '(min-width: 0px)',
           'sizesSupported': [
@@ -312,7 +322,7 @@ arcAds.registerAd({
         bidder: 'appnexus',
         labels: ['desktop', 'tablet', 'phone'],
         params: {
-          placementId: '10433394' 
+          placementId: '10433394'
         }
       }]
     }
@@ -321,7 +331,7 @@ arcAds.registerAd({
 ```
 
 ### Amazon TAM/A9
-You can enable Amazon A9/TAM on the service by adding an `amazon` object to the wrapper initialization and then passing it `enabled: true`. You must also include the `apstag` script on your page with: 
+You can enable Amazon A9/TAM on the service by adding an `amazon` object to the wrapper initialization and then passing it `enabled: true`. You must also include the `apstag` script on your page with:
 ```
 <script src="https://c.amazon-adsystem.com/aax2/apstag.js"></script>
 ```
@@ -384,7 +394,7 @@ const ads = [{
           bidder: 'appnexus',
           labels: ['desktop', 'tablet', 'phone'],
           params: {
-            placementId: '10433394' 
+            placementId: '10433394'
           }
         }]
       }
@@ -402,7 +412,7 @@ const ads = [{
           bidder: 'appnexus',
           labels: ['desktop', 'tablet', 'phone'],
           params: {
-            placementId: '10433394' 
+            placementId: '10433394'
           }
         }]
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arcads",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/__tests__/arcads.test.js
+++ b/src/__tests__/arcads.test.js
@@ -3,7 +3,8 @@ import { ArcAds } from '../index';
 describe('arcads', () => {
   const arcAds = new ArcAds({
     dfp: {
-      id: '123'
+      id: '123',
+      personalized: 1
     },
     bidding: {
       amazon: {
@@ -26,7 +27,7 @@ describe('arcads', () => {
       expect(googletag).toBeDefined();
     });
 
-    it('should initialize header bidding serivces', () => {
+    it('should initialize header bidding services', () => {
       const { arcBiddingReady } = global;
       expect(arcBiddingReady).toBeDefined();
     });

--- a/src/__tests__/arcads.test.js
+++ b/src/__tests__/arcads.test.js
@@ -4,7 +4,7 @@ describe('arcads', () => {
   const arcAds = new ArcAds({
     dfp: {
       id: '123',
-      personalized: 1
+      nonPersonalized: 1
     },
     bidding: {
       amazon: {

--- a/src/__tests__/gpt.test.js
+++ b/src/__tests__/gpt.test.js
@@ -99,7 +99,7 @@ describe('arcads', () => {
           refresh: 'true'
         }
       });
-    
+
       expect(methods.prepareSizeMaps.mock.calls.length).toBe(1);
       expect(methods.setResizeListener.mock.calls.length).toBe(1);
     });

--- a/src/index.js
+++ b/src/index.js
@@ -11,11 +11,12 @@ export class ArcAds {
     this.wrapper = options.bidding || {};
     this.positions = [];
     this.collapseEmptyDivs = options.dfp.collapseEmptyDivs;
+    this.nonPersonalized = options.dfp.nonPersonalized || 0;
 
     window.isMobile = MobileDetection;
 
     if (this.dfpId === '') {
-      console.warn(`ArcAds: DFP id is missing from the arcads initialization script. 
+      console.warn(`ArcAds: DFP id is missing from the arcads initialization script.
         Documentation: https://github.com/wapopartners/arc-ads#getting-started`);
     } else {
       initializeGPT();

--- a/src/services/gpt.js
+++ b/src/services/gpt.js
@@ -84,6 +84,7 @@ export function dfpSettings(handleSlotRenderEnded) {
   window.googletag.pubads().disableInitialLoad();
   window.googletag.pubads().enableSingleRequest();
   window.googletag.pubads().enableAsyncRendering();
+  window.googletag.pubads().setRequestNonPersonalizedAds(this.nonPersonalized);
   if (this.collapseEmptyDivs) {
     window.googletag.pubads().collapseEmptyDivs();
   }


### PR DESCRIPTION
## On this branch
Add non-personalized ads option to DFP configuration

#### Verify

- [X] Confirm that cross browser testing has been completed.

- [X] Verify that no errors are present in the GPT console `window.googletag.openConsole()`.
 

#### Comments
_Include any comments to help with an effective code review here_
