### PR TITLE
ci: Include only arcads dist output not testfiles or source ones, massive perf improvement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arcads",
-  "version": "5.0.0",
+  "version": "6.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcads",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "ArcAds is a GPT wrapper created by Arc XP with publishers in mind.",
   "main": "dist/arcads.js",
   "files": [


### PR DESCRIPTION
assumptions: 
- Clients nor us are using the src/ or actual test files here 

done: 
- entrypoint is dist/arcads.js
- only need that file 

## before 

howardj@arc-20750 ArcAds % npm publish --dry-run                         
npm notice 
npm notice 📦  arcads@6.1.0
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE                            
npm notice 803B   .eslintrc.js                       
npm notice 1.8kB  src/services/amazon.js             
npm notice 1.0kB  src/__tests__/amazon.test.js       
npm notice 19.8kB dist/arcads.js                     
npm notice 5.3kB  src/__tests__/arcads.test.js       
npm notice 690B   src/util/customTargeting.js        
npm notice 605B   src/util/debounce.js               
npm notice 1.3kB  debugging.js                       
npm notice 7.1kB  src/__tests__/displayAd.test.js    
npm notice 4.4kB  src/services/gpt.js                
npm notice 6.9kB  src/__tests__/gpt.test.js          
npm notice 4.8kB  src/services/headerbidding.js      
npm notice 2.8kB  src/__tests__/headerbidding.test.js
npm notice 11.1kB src/index.js                       
npm notice 113B   jest.config.js                     
npm notice 182B   jestPreprocess.js                  
npm notice 668B   src/util/log.js                    
npm notice 2.4kB  src/util/mobile.js                 
npm notice 11.8kB src/__tests__/mobile.test.js       
npm notice 1.2kB  src/util/polyfills.js              
npm notice 2.7kB  src/services/prebid.js             
npm notice 2.4kB  src/__tests__/prebid.test.js       
npm notice 713B   src/util/query.js                  
npm notice 887B   src/__tests__/query.test.js        
npm notice 9.3kB  src/__tests__/registerAds.test.js  
npm notice 903B   src/util/resources.js              
npm notice 1.6kB  src/__tests__/resources.test.js    
npm notice 6.1kB  src/services/sizemapping.js        
npm notice 2.9kB  src/__tests__/sizemapping.test.js  
npm notice 2.4kB  src/__tests__/util.test.js         
npm notice 1.3kB  webpack.config.js                  
npm notice 101B   .esdoc.json                        
npm notice 1.8kB  package.json                       
npm notice 1.9kB  CONTRIBUTING.md                    
npm notice 105B   .github/issue_template.md          
npm notice 332B   .github/pull_request_template.md   
npm notice 19.2kB README.md                          
npm notice 433B   .circleci/config.yml               
npm notice === Tarball Details === 
npm notice name:          arcads                                  
npm notice version:       6.1.0                                   
npm notice package size:  34.7 kB                                 
npm notice unpacked size: 140.9 kB                                
npm notice shasum:        49bf2c70352e6231a97c3bbed9f728914122b23f
npm notice integrity:     sha512-jj3Hd0C3k/Ca7[...]6An629D7U9WBw==
npm notice total files:   39                                      
npm notice 
+ arcads@6.1.0

## after 

howardj@arc-20750 ArcAds % npm publish --dry-run
npm notice 
npm notice 📦  arcads@6.1.0
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE       
npm notice 19.8kB dist/arcads.js
npm notice 1.8kB  package.json  
npm notice 19.2kB README.md     
npm notice === Tarball Details === 
npm notice name:          arcads                                  
npm notice version:       6.1.0                                   
npm notice package size:  13.6 kB                                 
npm notice unpacked size: 41.8 kB                                 
npm notice shasum:        c5690ecb6ddc7cc1c6c490003745b65dcfa629e5
npm notice integrity:     sha512-N7VFrhaKvnKMH[...]d7F+Z6gBOLMpA==
npm notice total files:   4                                       
npm notice 
+ arcads@6.1.0